### PR TITLE
Escape HTML characters in error message

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -77,7 +77,7 @@ class Application
         http_response_code($httpCode);
         echo "Internal error.";
         if ($message) {
-            echo " $message";
+            echo htmlspecialchars(" $message");
         }
         exit;
     }


### PR DESCRIPTION
Vypisování chybových hlášek bez escapování by potenciálně mohl být bezpečnostní problém. Chybové hlášky by mohly obsahovat HTML kód pocházející z parametrů požadavku.